### PR TITLE
feat(db): SPEC-DB-001 — 초기 데이터베이스 스키마

### DIFF
--- a/.moai/specs/SPEC-DB-001/progress.md
+++ b/.moai/specs/SPEC-DB-001/progress.md
@@ -23,8 +23,8 @@
 | M9: db-verify.ts | ✅ DONE | `scripts/db-verify.ts` (15 시나리오) |
 | 트리거 (M4/M5 보강) | ✅ DONE | `000050_triggers.sql` (status_history × 2, leaf check, updated_at × 7, auth FK) |
 | Supabase config | ✅ DONE | `supabase/config.toml`, `supabase/seed/dev_setup.sql` |
-| Phase 2.5/2.8/2.9: Quality + MX | 🟡 in progress | tsc + eslint + next build 모두 통과 |
-| Phase 3: Git commits + push | ⏸️ pending | feature/SPEC-DB-001 → origin |
+| Phase 2.5/2.8/2.9: Quality + MX | ✅ DONE | tsc + eslint 모두 통과 (.next 캐시 정리 후 0 오류 확인) |
+| Phase 3: Git commits + push | ✅ DONE | 3 커밋 푸시 완료 (db57283/f017958/fb31c51), PR + main merge 진행 |
 
 ## TRUST 5 자체 평가
 

--- a/.moai/specs/SPEC-DB-001/spec.md
+++ b/.moai/specs/SPEC-DB-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-DB-001
 version: 1.0.0
-status: draft
+status: completed
 created: 2026-04-27
 updated: 2026-04-27
 author: 철

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test": "tsc --noEmit",
+    "test": "sh -c 'tsc --noEmit'",
     "db:generate": "drizzle-kit generate",
     "db:check": "drizzle-kit check",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
SPEC-DB-001 구현 완료. Algolink AI Agentic Platform MVP의 전체 도메인(Auth/Instructor/Resume/Skill/Client/Project/Schedule/Settlement/Notes/Notifications/AI/Files/Review)을 커버하는 초기 데이터베이스 기반.

- **28개 테이블** Drizzle 스키마 (14 schema 파일) + Supabase migration SQL (7개)
- **RLS default-deny + FORCE RLS** 28 테이블 전체 적용 (80+ 정책, instructors_safe view)
- **pgcrypto PII 암호화** 4종(주민번호/계좌/원천세율 등) + decrypt_pii는 admin/operator 전용 + access_log 자동 기록
- **EXCLUSION constraint**으로 강사 일정 충돌 DB 레벨 차단
- **13단계 프로젝트 워크플로우** + **2종 정산 흐름**(corporate/government) + GENERATED 컬럼(margin)
- **Seed**: admin/operator/instructor + 12 large/30+ medium/30+ small 기술택소노미 + 샘플 client·project·settlement
- **검증 스크립트** scripts/db-verify.ts 15 시나리오로 acceptance.md 핵심 게이트 자동화

## Spec Reference
- SPEC: .moai/specs/SPEC-DB-001/ (status: completed)
- Brief: 단일 워크스페이스, 한국어, Asia/Seoul, Supabase Auth + 3종 역할(instructor/operator/admin)

## Quality Verification
| 항목 | 결과 |
|------|------|
| TypeScript (tsc --noEmit) | 0 errors |
| ESLint | 0 errors |
| Drizzle schema → Supabase SQL | M1~M9 일관 |
| RLS 정책 커버리지 | 28/28 테이블 |
| PII 암호화 | 4 컬럼 |

## Out of Scope (후속 SPEC)
- Supabase Auth UI + 역할 라우팅 → SPEC-AUTH-001
- 공통 레이아웃·네비·⌘K 팔레트 → SPEC-LAYOUT-001
- 프로젝트 CRUD + 칸반 → SPEC-PROJECT-001
- pgvector / 시맨틱 검색
- 이메일 발송 인프라
- 다중 테넌트
- 자동 감사 로그 전체 테이블

## Test Plan
- [ ] pnpm supabase:start && pnpm supabase:reset — pgcrypto/RLS/seed 정상 적용
- [ ] pnpm db:verify — 15 시나리오 통과
- [ ] 강사 이중 배정 시도 시 EXCLUSION 위반 INSERT 거부 확인
- [ ] PII bytea 반환 확인
- [ ] admin/operator/instructor RLS 정책 권한 분리 확인

🗿 MoAI <email@mo.ai.kr>