### PR TITLE
fix(db): SPEC-DB-001 — migration 30의 pii_access_log 중복 정의 제거

### DIFF
--- a/supabase/migrations/20260427000030_initial_schema.sql
+++ b/supabase/migrations/20260427000030_initial_schema.sql
@@ -28,12 +28,9 @@ CREATE TABLE "files" (
 	"uploaded_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "pii_access_log" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"caller_id" uuid,
-	"target_instructor_id" uuid,
-	"accessed_at" timestamp with time zone DEFAULT now() NOT NULL
-);
+-- pii_access_log은 20260427000020_pgcrypto_functions.sql에서 CREATE TABLE IF NOT EXISTS로 먼저 생성됨.
+-- Drizzle 자동 생성된 중복 정의는 깨끗한 reset에서 SQLSTATE 42P07를 일으키므로 제거.
+-- (Drizzle schema src/db/schema/pii-log.ts는 그대로 유지하여 ORM 레이어 일관성 보존.)
 --> statement-breakpoint
 CREATE TABLE "instructors" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -374,9 +371,8 @@ ALTER TABLE "satisfaction_reviews" ADD CONSTRAINT "satisfaction_reviews_instruct
 ALTER TABLE "satisfaction_reviews" ADD CONSTRAINT "satisfaction_reviews_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "idx_files_owner" ON "files" USING btree ("owner_id");--> statement-breakpoint
 CREATE INDEX "idx_files_uploaded_at" ON "files" USING btree ("uploaded_at" DESC NULLS LAST);--> statement-breakpoint
-CREATE INDEX "idx_pii_access_log_caller" ON "pii_access_log" USING btree ("caller_id");--> statement-breakpoint
-CREATE INDEX "idx_pii_access_log_target" ON "pii_access_log" USING btree ("target_instructor_id");--> statement-breakpoint
-CREATE INDEX "idx_pii_access_log_accessed_at" ON "pii_access_log" USING btree ("accessed_at");--> statement-breakpoint
+-- pii_access_log 인덱스는 20260427000020_pgcrypto_functions.sql:21-23에서 CREATE INDEX IF NOT EXISTS로 이미 생성됨.
+--> statement-breakpoint
 CREATE INDEX "idx_instructors_user_id" ON "instructors" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "idx_instructors_email" ON "instructors" USING btree ("email");--> statement-breakpoint
 CREATE INDEX "idx_instructors_deleted" ON "instructors" USING btree ("deleted_at");--> statement-breakpoint


### PR DESCRIPTION
## Summary

마이그레이션 30(Drizzle 자동 생성)이 pii_access_log를 중복 정의하여 깨끗한 reset에서 SQLSTATE 42P07로 실패. 마이그레이션 20이 권위 정의이므로 30의 중복을 제거.

## Bug Reproduction

\`\`\`bash
pnpm supabase:start
# ...
# Applying migration 20260427000030_initial_schema.sql...
# ERROR: relation "pii_access_log" already exists (SQLSTATE 42P07)
\`\`\`

## Root Cause

- 마이그레이션 20 (`pgcrypto_functions.sql:14`) — `CREATE TABLE IF NOT EXISTS pii_access_log` (멱등, `decrypt_pii()` 함수가 INSERT 의존)
- 마이그레이션 30 (`initial_schema.sql:31`) — `CREATE TABLE \"pii_access_log\"` (Drizzle 자동 생성, 비멱등)

## Fix

Drizzle 자동 생성된 마이그레이션 30의 pii_access_log CREATE TABLE + 3 indices를 주석으로 대체. 마이그레이션 20을 권위 정의로 유지 (스키마/인덱스 동일).

## Test plan

- [x] `pnpm tsc --noEmit` — 0 error (변경 없음)
- [x] FK/RLS 영향 분석: 마이그레이션 30 어디에도 pii_access_log 참조 없음, 마이그레이션 60의 RLS 정책은 테이블 출처와 무관
- [ ] 로컬 `pnpm supabase:start` 통과 (다음 단계 SPEC-AUTH-001 라이브 검증 시 검증)

## Notes

- ORM 레이어 `src/db/schema/pii-log.ts`는 그대로 유지 (Drizzle 일관성)
- 향후 `pnpm db:generate` 재실행 시 중복이 다시 발생할 수 있음 → 별도 PR로 Drizzle 설정 또는 마이그레이션 20을 마이그레이션 25로 이동시키는 구조 개선 고려

## Relation

- SPEC-AUTH-001 PR #5의 라이브 검증 차단 요인
- main에 먼저 머지 → SPEC-AUTH-001 브랜치 rebase 후 검증 재개

🗿 MoAI <email@mo.ai.kr>