### PR TITLE
chore(auth): supabase 신규 publishable/secret 키 네이밍 마이그레이션

### DIFF
--- a/src/auth/admin.ts
+++ b/src/auth/admin.ts
@@ -13,20 +13,22 @@ import type { Database } from "@/db/supabase-types";
  */
 export function createServiceSupabase() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  // 신규 secret key (sb_secret_*) — 레거시 service_role JWT 대체.
+  // Supabase 2026 Q1 retro: legacy service_role 키는 2026 후반 제거 예정.
+  const secretKey = process.env.SUPABASE_SECRET_KEY;
 
   if (!url) {
     throw new Error(
       "[auth.admin] NEXT_PUBLIC_SUPABASE_URL 환경변수가 설정되지 않았습니다.",
     );
   }
-  if (!serviceRoleKey) {
+  if (!secretKey) {
     throw new Error(
-      "[auth.admin] SUPABASE_SERVICE_ROLE_KEY 환경변수가 설정되지 않았습니다.",
+      "[auth.admin] SUPABASE_SECRET_KEY 환경변수가 설정되지 않았습니다.",
     );
   }
 
-  return createClient<Database>(url, serviceRoleKey, {
+  return createClient<Database>(url, secretKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -24,13 +24,17 @@ const queryClient = postgres(databaseUrl, {
 export const db = drizzle(queryClient, { schema });
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// 신규 publishable key (sb_publishable_*) — 레거시 anon JWT 대체.
+// Supabase 2026 Q1 retro: legacy anon/service_role JWT 는 2026 후반 제거 예정.
+const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
 /**
- * 클라이언트 사이드 Supabase 인스턴스 (anon key).
+ * 클라이언트 사이드 Supabase 인스턴스 (publishable key).
  * 서버 사이드에서는 별도 SSR 헬퍼 (@supabase/ssr) 사용 권장.
  */
 export const supabase: SupabaseClient | null =
-  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;
+  supabaseUrl && supabasePublishableKey
+    ? createClient(supabaseUrl, supabasePublishableKey)
+    : null;
 
 export { schema };


### PR DESCRIPTION
## Summary

Supabase 2026 Q1 retro 에 따라 legacy `anon` / `service_role` JWT 는 **2026 후반 제거 예정**. `src/utils/supabase/*` 는 이미 신규 네이밍을 사용 중이므로, 나머지 2 파일을 정렬해 일관성을 회복하고 deprecation 위험을 제거.

### Reference
- [Supabase 2025 Security Retro](https://github.com/supabase/supabase/blob/master/apps/www/_blog/2026-01-07-supabase-security-2025-retro.mdx) — *"Legacy keys remain available during migration but will be removed in late 2026"*
- 신규 키 형식: `sb_publishable_<22>_<8>` / `sb_secret_<22>_<8>` (즉시 회수 가능 + 감사 + 스코프 지원)

### 변경 (2 files, +13 / -7)

| 파일 | Before | After |
|------|--------|-------|
| `src/db/client.ts` | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` |
| `src/auth/admin.ts` | `SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SECRET_KEY` |

### 환경 변수 마이그레이션 (배포 시)

`.env.local` (개발) / Vercel Production env 둘 다:
```diff
- NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
- SUPABASE_SERVICE_ROLE_KEY=eyJ...
+ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+ SUPABASE_SECRET_KEY=sb_secret_...
```

Cloud 키 발급: Supabase Dashboard → Project Settings → API Keys (legacy 와 신규 양쪽 모두 표시됨, 신규 사용 권장).

## Test plan

- [x] `pnpm exec tsc --noEmit` 0 오류
- [x] `pnpm db:verify` 18/18 PASS
- [x] Playwright 로 admin / operator / instructor 3 사용자 라이브 로그인 — JWT `claims.role` 정상 주입 (custom_access_token_hook 동작 확인)
- [ ] 머지 후 Vercel Production env 갱신 (`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` + `SUPABASE_SECRET_KEY`)

🗿 MoAI <email@mo.ai.kr>