### PR TITLE
fix(auth): SPEC-AUTH-001 — instructor ROLE_HOME 을 /me 로 정합화

### DIFF
--- a/src/app/(app)/(operator)/layout.tsx
+++ b/src/app/(app)/(operator)/layout.tsx
@@ -1,7 +1,7 @@
 import { requireRole } from "@/auth/guards";
 
 // SPEC-AUTH-001 §2.5 REQ-AUTH-GUARD-004: operator+admin 공용 라우트 가드.
-// instructor 접근 시 /me/dashboard로 silent redirect.
+// instructor 접근 시 /me 로 silent redirect.
 export default async function OperatorLayout({
   children,
 }: {

--- a/src/auth/__tests__/roles.test.ts
+++ b/src/auth/__tests__/roles.test.ts
@@ -22,7 +22,7 @@ test("isValidRole: 그 외 값은 false", () => {
 });
 
 test("roleHomePath: 역할별 home 경로", () => {
-  assert.equal(roleHomePath("instructor"), "/me/dashboard");
+  assert.equal(roleHomePath("instructor"), "/me");
   assert.equal(roleHomePath("operator"), "/dashboard");
   assert.equal(roleHomePath("admin"), "/dashboard");
 });

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -4,8 +4,11 @@
 
 export type UserRole = "instructor" | "operator" | "admin";
 
+// 강사 홈은 src/app/(app)/(instructor)/me/page.tsx (InstructorDashboardPage) 가
+// 실제로 대시보드 컨텐츠를 렌더하므로 /me 로 정렬한다.
+// 이전 값 "/me/dashboard" 는 라우트가 존재하지 않아 404 + 다른 역할의 layout 가드 우회를 유발했다.
 export const ROLE_HOME: Record<UserRole, string> = {
-  instructor: "/me/dashboard",
+  instructor: "/me",
   operator: "/dashboard",
   admin: "/dashboard",
 };


### PR DESCRIPTION
## Summary

라이브 테스트(Playwright, admin/operator/instructor 3 사용자) 결과 SPEC-AUTH-001 의 instructor 홈 매핑이 실재 라우트와 어긋난 상태였음. **1줄 + 정합 변경 2건** 으로 해소.

### 증상

| # | 시나리오 | 기대 | 실제 |
|---|----------|------|------|
| 1 | instructor 로그인 직후 | `/me/dashboard` 정상 렌더 | 404 |
| 2 | admin 이 `/me/dashboard` 접근 | instructor layout 가드가 `/dashboard` 로 silent redirect | 가드 우회 → 404 페이지 그대로 표시 |

### 근본 원인

- 실재 라우트: `src/app/(app)/(instructor)/me/page.tsx` 가 이미 `InstructorDashboardPage` (예정 프로젝트 + 정산 + AI 인사이트) 를 렌더 — 강사 대시보드는 `/me` 자체.
- `/me/dashboard/` 폴더는 존재하지 않음 → Next.js 가 `(instructor)/layout.tsx` 호출 없이 글로벌 not-found 로 단락 → admin/operator 도 가드 없이 페이지 도달.
- ROLE_HOME 매핑만 가상의 `/me/dashboard` 를 가리켜 정합이 깨짐.

### 변경 (3 files, +5 / -3)

| 파일 | 변경 |
|------|------|
| `src/auth/roles.ts` | `ROLE_HOME.instructor`: `/me/dashboard` → `/me` (+ 의도 주석) |
| `src/auth/__tests__/roles.test.ts` | 단위 테스트 기대값 업데이트 |
| `src/app/(app)/(operator)/layout.tsx` | 주석 정합화 |

## Test plan

- [x] `pnpm exec tsc --noEmit`: 0 오류
- [x] `pnpm exec tsx --test src/auth/__tests__/roles.test.ts`: 6/6 PASS
- [ ] (머지 후) Playwright 재실행 — instructor 로그인 시 `/me` 정상 렌더 + admin/operator 의 `/me/*` 차단 확인

🗿 MoAI <email@mo.ai.kr>