### PR TITLE
fix(mobile): drawer 폭/높이/safe-area 폴리시 (SPEC-MOBILE-001 follow-up)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -301,6 +301,14 @@ body {
   from { transform: translateX(0); }
   to { transform: translateX(100%); }
 }
+@keyframes algolink-slide-in-left {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+@keyframes algolink-slide-out-left {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
 @keyframes algolink-slide-in-bottom {
   from { transform: translateY(8px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
@@ -320,6 +328,12 @@ body {
 }
 [data-state="closed"][data-radix-dialog-content][data-side="right"] {
   animation: algolink-slide-out-right var(--motion-duration-default) var(--motion-easing-out);
+}
+[data-state="open"][data-radix-dialog-content][data-side="left"] {
+  animation: algolink-slide-in-left var(--motion-duration-slow) var(--motion-easing-out);
+}
+[data-state="closed"][data-radix-dialog-content][data-side="left"] {
+  animation: algolink-slide-out-left var(--motion-duration-default) var(--motion-easing-out);
 }
 [data-state="open"][data-radix-dialog-content]:not([data-side]) {
   animation: algolink-slide-in-bottom var(--motion-duration-slow) var(--motion-easing-out);

--- a/src/components/app/mobile-nav.tsx
+++ b/src/components/app/mobile-nav.tsx
@@ -46,7 +46,11 @@ export function MobileNav({ sections }: MobileNavProps) {
           <Menu className="size-5" />
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="w-72 p-0 pb-safe">
+      {/* SPEC-MOBILE-001 §M2 follow-up: drawer 폭/높이/safe-area + dark bg 정합 */}
+      <SheetContent
+        side="left"
+        className="flex w-[85vw] max-w-[320px] flex-col bg-[var(--color-secondary)] p-0 pt-safe pb-safe text-[var(--color-secondary-foreground)]"
+      >
         <Sidebar sections={sections} forceVisible />
       </SheetContent>
     </Sheet>

--- a/src/components/app/sidebar.tsx
+++ b/src/components/app/sidebar.tsx
@@ -27,14 +27,24 @@ export function Sidebar({ sections, collapsed = false, forceVisible = false }: S
       <aside
         className={cn(
           "flex-col bg-[var(--color-secondary)] text-[var(--color-secondary-foreground)] transition-[width] duration-150",
-          forceVisible ? "flex" : "hidden lg:flex",
-          collapsed ? "w-[var(--layout-sidebar-width-collapsed)]" : "w-[var(--layout-sidebar-width)]",
+          forceVisible
+            ? "flex h-full w-full"
+            : cn(
+                "hidden lg:flex",
+                collapsed
+                  ? "w-[var(--layout-sidebar-width-collapsed)]"
+                  : "w-[var(--layout-sidebar-width)]",
+              ),
         )}
-        style={{
-          width: collapsed
-            ? "var(--layout-sidebar-width-collapsed)"
-            : "var(--layout-sidebar-width)",
-        }}
+        style={
+          forceVisible
+            ? undefined
+            : {
+                width: collapsed
+                  ? "var(--layout-sidebar-width-collapsed)"
+                  : "var(--layout-sidebar-width)",
+              }
+        }
         aria-label="주 내비게이션"
       >
         {/* Logo */}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -29,13 +29,13 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-[var(--color-surface)] p-6 shadow-lg transition ease-in-out",
+  "fixed z-50 flex flex-col gap-4 bg-[var(--color-surface)] p-6 shadow-lg transition ease-in-out",
   {
     variants: {
       side: {
         top: "inset-x-0 top-0 border-b data-[state=open]:animate-[algolink-slide-in-bottom_200ms_cubic-bezier(0,0,0.2,1)]",
         bottom: "inset-x-0 bottom-0 border-t",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+        left: "inset-y-0 left-0 h-dvh w-3/4 border-r sm:max-w-sm data-[state=open]:animate-[algolink-slide-in-left_200ms_cubic-bezier(0,0,0.2,1)] data-[state=closed]:animate-[algolink-slide-out-left_150ms_cubic-bezier(0.4,0,1,1)]",
         right:
           "inset-y-0 right-0 h-full w-full border-l sm:max-w-xl data-[state=open]:animate-[algolink-slide-in-right_200ms_cubic-bezier(0,0,0.2,1)] data-[state=closed]:animate-[algolink-slide-out-right_150ms_cubic-bezier(0.4,0,1,1)]",
       },
@@ -61,10 +61,10 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       <SheetPrimitive.Close
-        className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2"
+        className="absolute right-3 top-3 z-10 inline-flex h-9 w-9 items-center justify-center rounded-md text-current/70 transition-colors hover:bg-foreground/10 hover:text-current focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2"
         aria-label="닫기"
       >
-        <X className="h-4 w-4" />
+        <X className="h-5 w-5" />
       </SheetPrimitive.Close>
       {children}
     </SheetPrimitive.Content>


### PR DESCRIPTION
## 요약

PR #11 (SPEC-MOBILE-001) 머지 직후 현장에서 발견된 drawer UX 결함 5종 fix.

## 결함 (스크린샷 진단)

1. drawer 하단 흰 띠 (sidebar height 미지정)
2. drawer 우측 흰 띠 (sidebar inline width와 SheetContent 폭 mismatch)
3. close button drawer 외부 floating처럼 보임
4. slide-in-left 애니메이션 누락 (right만 keyframe 존재)
5. iOS safe-area 미보정

## 수정 (4 files, +40/-12)

- `src/app/globals.css` (+10): `algolink-slide-in-left` / `algolink-slide-out-left` keyframe 2종 + `[data-side=left]` selector 2종
- `src/components/ui/sheet.tsx` (±5): base에 `flex flex-col` / left variant `h-full → h-dvh` + slide-in-left 애니메이션 / Close 버튼 9x9 터치영역 + z-10 + focus-visible
- `src/components/app/mobile-nav.tsx` (+5): SheetContent `w-[85vw] max-w-[320px]` + `flex flex-col` + `bg-secondary` + `pt-safe pb-safe`
- `src/components/app/sidebar.tsx` (±10): `forceVisible` 시 `h-full w-full`, inline width style 분기 적용

## 회귀 가드

- desktop sidebar (forceVisible=false): inline width 토큰 + `lg:flex` 동작 무변경
- SPEC-LAYOUT-001 토큰 49종 + SPEC-MOBILE-001 토큰 9종 변경 0
- DB / API / migrations 변경 0

## 검증

- [x] pnpm tsc --noEmit PASS (0 error)
- [x] pnpm build PASS
- [x] eslint 영향 없음
- [ ] 시각 검증 (Vercel preview 후)

🗿 MoAI <email@mo.ai.kr>